### PR TITLE
Support minimal Mac OS X by removing Linux specifics

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -78,6 +78,18 @@ link '/etc/init.d/bamboo-agent' do
   not_if { node[:platform_family] == 'mac_os_x' }
 end
 
+template '/Library/LaunchDaemons/bamboo-agent.plist' do
+  source 'bamboo-agent.plist.erb'
+  owner 'root'
+  group 'wheel'
+  mode 0644
+  variables(
+    :username => node[:bamboo][:agent][:user],
+    :data_dir => node[:bamboo][:agent][:data_dir]
+  )
+  only_if { node[:platform_family] == 'mac_os_x' }
+end
+
 capabilities = node[:bamboo][:agent_capabilities]
 template 'bamboo-capabilities.properties' do
   path "#{node[:bamboo][:agent][:data_dir]}/bin/bamboo-capabilities.properties"
@@ -88,14 +100,14 @@ template 'bamboo-capabilities.properties' do
   variables(
     :options => capabilities
   )
-  notifies :restart, 'service[bamboo-agent]', :delayed unless node[:platform_family] == 'mac_os_x'
+  notifies :restart, 'service[bamboo-agent]', :delayed
 end
 
 # Create and enable service
 service 'bamboo-agent' do
   supports :restart => true, :status => true, :start => true, :stop => true
+  provider Chef::Provider::Service::Macosx if node[:platform_family] == 'mac_os_x'
   action [:enable, :start]
-  not_if { node[:platform_family] == 'mac_os_x' }
 end
 
 # Setup monit

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -82,7 +82,7 @@ template '/Library/LaunchDaemons/bamboo-agent.plist' do
   source 'bamboo-agent.plist.erb'
   owner 'root'
   group 'wheel'
-  mode 0644
+  mode '0644'
   variables(
     :username => node[:bamboo][:agent][:user],
     :data_dir => node[:bamboo][:agent][:data_dir]

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -75,6 +75,7 @@ end
 
 link '/etc/init.d/bamboo-agent' do
   to "#{node[:bamboo][:agent][:data_dir]}/bin/bamboo-agent.sh"
+  not_if { node[:platform_family] == 'mac_os_x' }
 end
 
 capabilities = node[:bamboo][:agent_capabilities]
@@ -87,18 +88,20 @@ template 'bamboo-capabilities.properties' do
   variables(
     :options => capabilities
   )
-  notifies :restart, 'service[bamboo-agent]', :delayed
+  notifies :restart, 'service[bamboo-agent]', :delayed unless node[:platform_family] == 'mac_os_x'
 end
 
 # Create and enable service
 service 'bamboo-agent' do
   supports :restart => true, :status => true, :start => true, :stop => true
   action [:enable, :start]
+  not_if { node[:platform_family] == 'mac_os_x' }
 end
 
 # Setup monit
 package 'monit' do
   action :install
+  not_if { node[:platform_family] == 'mac_os_x' }
 end
 
 template 'procfile.monitrc' do
@@ -106,11 +109,13 @@ template 'procfile.monitrc' do
   owner  'root'
   group  'root'
   mode '0644'
-  notifies :restart, 'service[monit]', :delayed
+  notifies :restart, 'service[monit]', :delayed unless node[:platform_family] == 'mac_os_x'
+  not_if { node[:platform_family] == 'mac_os_x' }
 end
 
 # Create and enable service
 service 'monit' do
   supports :restart => true, :status => true, :start => true, :stop => true
   action [:enable, :start]
+  not_if { node[:platform_family] == 'mac_os_x' }
 end

--- a/templates/default/bamboo-agent.plist.erb
+++ b/templates/default/bamboo-agent.plist.erb
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>bamboo-agent</string>
+  <key>ProgramArguments</key>
+    <array>
+      <string><%= @data_dir %>/bin/bamboo-agent.sh</string>
+      <string>start</string>
+    </array>
+  <key>UserName</key>
+  <string><%= @username %></string>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>
+


### PR DESCRIPTION
I am currently using this cookbook to install an agent on Mac OS X and it is working with these changes. I'd like to simply use your cookbook versus a fork, so it would be great if we could get this included. I can look into what is necessary to make the service auto-start on boot and will submit another PR for that, once done.