### PR TITLE
Create agent wrapper.conf from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Installs/Configures [Atlassian Bamboo](https://www.atlassian.com/software/Bamboo
 
 ### Platforms
 
+* CentOS 6.x
+* Mac OS X 10.10
 * Ubuntu 14.04
 
 ### Databases
@@ -75,6 +77,7 @@ data_dir | Bamboo data directory | String | /var/bamboo
 user | user to run Bamboo | String | bamboo
 group | group for user bamboo | String | bamboo
 user_home | home dir for user bamboo | String | /home/bamboo
+ping_timeout | timeout until wrapper restarts unresponsive JVM | Integer | 30
 disable_agent_auto_capability_detection | sets the flag on the agent | String | true
 additional_path | will be added to the $PATH of the agent process | String |
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,6 +76,7 @@ default[:bamboo][:agent][:data_dir]               = '/var/bamboo'               
 default[:bamboo][:agent][:user]                   = 'bamboo'                            # bamboo user
 default[:bamboo][:agent][:group]                  = 'bamboo'                            # bamboo group
 default[:bamboo][:agent][:user_home]              = '/home/bamboo'                      # bamboo system user home directory
+default[:bamboo][:agent][:ping_timeout]           = 30                                  # JVM timeout before wrapper restarts agent
 default[:bamboo][:agent][:disable_agent_auto_capability_detection] = true
 default[:bamboo][:agent][:additional_path]        = ''
 default[:bamboo][:agent_capabilities]             = {}
@@ -106,4 +107,4 @@ default[:bamboo][:backup][:minute]                = '*'
 
 # damn postgresql:ruby recipe still builds at compile time
 default[:apt][:compile_time_update] = true
-default['build-essential']['compile_time'] = true
+default['build-essential']['compile_time'] = true # ~FC019

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -103,6 +103,15 @@ template 'bamboo-capabilities.properties' do
   notifies :restart, 'service[bamboo-agent]', :delayed
 end
 
+template 'wrapper.conf' do
+  path "#{node[:bamboo][:agent][:data_dir]}/conf/wrapper.conf"
+  source 'agent-wrapper.conf.erb'
+  owner  node[:bamboo][:agent][:user]
+  group  node[:bamboo][:agent][:group]
+  mode '0644'
+  notifies :restart, 'service[bamboo-agent]', :delayed
+end
+
 # Create and enable service
 service 'bamboo-agent' do
   supports :restart => true, :status => true, :start => true, :stop => true

--- a/templates/default/agent-wrapper.conf.erb
+++ b/templates/default/agent-wrapper.conf.erb
@@ -1,0 +1,75 @@
+# Java Application
+wrapper.java.command=java
+
+# Java Main class.
+wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperSimpleApp
+
+# Java Classpath (include wrapper.jar)
+wrapper.java.classpath.1=../lib/wrapper.jar
+wrapper.java.classpath.2=../lib/bamboo-agent-bootstrap.jar
+
+# Java Library Path (location of Wrapper.DLL or libwrapper.so)
+wrapper.java.library.path.1=../lib
+
+# The Bamboo Agent home configuration file
+wrapper.java.additional.1=-Dbamboo.home=<%= node[:bamboo][:agent][:data_dir] %>
+wrapper.java.additional.2=-Dbamboo.agent.ignoreServerCertName=false
+#wrapper.java.additional.3=-agentlib:yjpagent
+
+# Application parameters.  Add parameters as needed starting from 1
+wrapper.app.parameter.1=com.atlassian.bamboo.agent.bootstrap.AgentBootstrap
+wrapper.app.parameter.2=<%= node[:bamboo][:url] %>/agentServer/
+
+# Disable shutdown hook so that
+wrapper.disable_shutdown_hook=TRUE
+
+# Set a wrapper timeout
+wrapper.ping.timeout=<%= node[:bamboo][:agent][:ping_timeout] %>
+
+# Initial Java Heap Size (in MB)
+wrapper.java.initmemory=256
+
+# Maximum Java Heap Size (in MB)
+wrapper.java.maxmemory=512
+
+
+#********************************************************************
+# Wrapper Logging Properties
+#********************************************************************
+wrapper.working.dir=.
+
+wrapper.console.format=LPTM
+wrapper.console.loglevel=INFO
+wrapper.console.flush=true
+wrapper.logfile=../atlassian-bamboo-agent.log
+wrapper.logfile.format=LPTM
+wrapper.logfile.loglevel=INFO
+wrapper.logfile.maxsize=10m
+wrapper.logfile.maxfiles=10
+wrapper.syslog.loglevel=INFO
+
+# How long should the wrapper wait before it considers an invocation successful?  3 seconds should be long
+# enough for any configuration errors to have been determined.
+wrapper.successful_invocation_time=3
+
+#********************************************************************
+# Wrapper Windows Properties
+#********************************************************************
+# Title to use when running as a console
+wrapper.console.title=Bamboo Remote Agent
+
+# Name of the service
+wrapper.ntservice.name=bamboo-remote-agent
+
+# Display name of the service
+wrapper.ntservice.displayname=Bamboo Remote Agent
+
+# Description of the service
+wrapper.ntservice.description=A remote agent for building Bamboo build plans.
+
+# Mode in which the service is installed.  AUTO_START or DEMAND_START
+wrapper.ntservice.starttype=AUTO_START
+
+# Allow the service to interact with the desktop.
+wrapper.ntservice.interactive=false
+


### PR DESCRIPTION
This is specifically to allow me to set `wrapper.ping.timeout` as my agents will sometimes shutdown while uploading large artifacts (500MB+) to the Bamboo server.

https://confluence.atlassian.com/bamkb/how-to-stop-bamboo-from-shutting-itself-down-and-restarting-179444239.html
