### PR TITLE
Fix issues related to test or MySQL + add tests for MySQL

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,8 @@ suites:
       - recipe[bamboo]
     attributes:
       bamboo:
+        jvm:
+          minimum_memory: '64m'
         name: bamboo-dev
         backup:
           enabled: false
@@ -31,3 +33,13 @@ suites:
         agent:
           data_dir: /var/bamboo-agent
           home_dir: /opt/bamboo-agent
+  - name: mysql-56
+    run_list:
+      - recipe[bamboo]
+    attributes:
+      bamboo:
+        jvm:
+          minimum_memory: '64m'
+        database:
+          type: 'mysql'
+          version: '5.6'

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -13,6 +13,11 @@ when 'mysql'
     action :create
   end
 
+  mysql2_chef_gem 'Default' do
+    client_version node[:bamboo][:database][:version]
+    action :install
+  end
+
   mysql_service 'default' do
     version node[:bamboo][:database][:version]
     bind_address node[:bamboo][:database][:host]

--- a/test/integration/mysql-56/serverspec/packages_spec.rb
+++ b/test/integration/mysql-56/serverspec/packages_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+packages = case
+           when os[:family] == 'ubuntu' &&  os[:release] == '12.04'
+             then ['mysql-server-5.5', 'apache2']
+           when os[:family] == 'ubuntu' &&  os[:release] == '14.04'
+             then ['mysql-server-5.6', 'apache2']
+           when os[:family] == 'redhat'
+             then ['mysql-community-client', 'mysql-community-server', 'httpd']
+           end
+
+packages.each do |package|
+  describe package(package) do
+    it { should be_installed }
+  end
+end
+
+

--- a/test/integration/mysql-56/serverspec/services_spec.rb
+++ b/test/integration/mysql-56/serverspec/services_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+# Check if all services are running
+services = if os[:family] == 'redhat'
+             # mysqld doesn't seem to be running as a service.  This should be
+             # fine since I would assume most people are going to run mysql off
+             # site on a external server.
+             %w(httpd bamboo)
+           else
+             %w(mysql-default apache2 bamboo)
+           end
+
+services.each do |service|
+  describe service(service) do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+# Ports: mysql, apache, bamboo
+ports = [3306, 80, 8085]
+
+ports.each do |port|
+  describe port(port) do
+    it { should be_listening }
+  end
+end

--- a/test/integration/mysql-56/serverspec/spec_helper.rb
+++ b/test/integration/mysql-56/serverspec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec

--- a/test/integration/mysql-56/serverspec/users_spec.rb
+++ b/test/integration/mysql-56/serverspec/users_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+# Test groups
+describe group('mysql') do
+  it { should exist }
+end
+
+describe group('bamboo') do
+  it { should exist }
+end
+
+# Test users
+describe user('bamboo') do
+  it { should exist }
+  it { should belong_to_group 'bamboo' }
+  it { should have_login_shell '/bin/bash' }
+end
+
+describe user('mysql') do
+  it { should exist }
+  it { should belong_to_group 'mysql' }
+end
+
+describe 'am i running' do
+  describe command('curl -L localhost:8085') do
+    its(:stdout) { should contain('Welcome to Atlassian Bamboo continuous integration server') }
+  end
+end


### PR DESCRIPTION
 - In tests, Tomcat crashes because it is started with too much
   minimal memory. Now it starts well with only 64M
 - mysql2 Gem install is required. It was in deps but not installed.
 - Add new test suite 'mysql-56' based simply on copy of default
   tests.

Let me know if you have any question.
Jean-Pierre